### PR TITLE
Add Meccha Chameleon Art fan atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ Once the application is up and running, you can access it by navigating to the a
 
 ## License
 This project is licensed under the MIT License - see the LICENSE file for details.
+## Related Community Resources
+
+<!-- Added 2026-06-24 by zlc000190 -->
+- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon, a paint-based hide-and-seek Steam game. 50+ hiding spot atlas with color/paint analysis, bilingual (EN/中文). GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot


### PR DESCRIPTION
## Community Resource

- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon, a paint-based hide-and-seek Steam game. 50+ hiding spot atlas with color/paint analysis, bilingual (EN/中文).
- GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot

Fan-made, unofficial. Meccha Chameleon is © LEMORION.